### PR TITLE
Support ktlint 0.41.0

### DIFF
--- a/flycheck-kotlin.el
+++ b/flycheck-kotlin.el
@@ -41,12 +41,11 @@
 (flycheck-define-checker kotlin-ktlint
   "A Kotlin syntax and style checker using the ktlint utility.
 See URL `https://github.com/shyiko/ktlint'."
-  :command ("ktlint" source-original)
+  :command ("ktlint" "--stdin")
   :error-patterns
-  ((error line-start (file-name) ":" line ":" column ": " (message) line-end))
+  ((error line-start "<stdin>:" line ":" column ": " (message) line-end))
   :modes kotlin-mode
-  :predicate flycheck-buffer-saved-p)
-
+  :standard-input t)
 
 ;;;###autoload
 (defun flycheck-kotlin-setup ()


### PR DESCRIPTION
ktlint version 0.41.0 removed support for absolute paths. Support for linting from stdin appeared in version 0.8.1 in May 2017, so this should be safe for all users.